### PR TITLE
Upgrade libraries org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,9 +21,9 @@ lazy val root = project
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.10.13",
       "org.joda" % "joda-convert" % "2.2.2",
-      "org.scalatest" %% "scalatest" % "3.2.10" % Test,
-      "org.scalatest" %% "scalatest-funspec" % "3.2.10" % Test,
-      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.10" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.11" % Test,
+      "org.scalatest" %% "scalatest-funspec" % "3.2.11" % Test,
+      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.11" % Test,
     )
 )
     credentials += Credentials(


### PR DESCRIPTION
- org.scalatest
  - scalatest (3.2.10 => 3.2.11)
  - scalatest-funspec (3.2.10 => 3.2.11)
  - scalatest-shouldmatchers (3.2.10 => 3.2.11)