### PR TITLE
Upgrade libraries joda-time, org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@ lazy val root = project
   .in(file("."))
   .settings(
     libraryDependencies ++= Seq(
-      "joda-time" % "joda-time" % "2.11.1",
+      "joda-time" % "joda-time" % "2.12.1",
       "org.joda" % "joda-convert" % "2.2.2",
-      "org.scalatest" %% "scalatest" % "3.2.13" % Test,
-      "org.scalatest" %% "scalatest-funspec" % "3.2.13" % Test,
-      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.13" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.14" % Test,
+      "org.scalatest" %% "scalatest-funspec" % "3.2.14" % Test,
+      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.14" % Test,
     )
 )
     credentials += Credentials(


### PR DESCRIPTION
- joda-time
  - joda-time (2.11.1 => 2.12.1)
- org.scalatest
  - scalatest (3.2.13 => 3.2.14)
  - scalatest-funspec (3.2.13 => 3.2.14)
  - scalatest-shouldmatchers (3.2.13 => 3.2.14)