### PR TITLE
Upgrade libraries org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,9 +24,9 @@ lazy val root = project
     libraryDependencies ++= Seq(
       "joda-time" % "joda-time" % "2.12.5",
       "org.joda" % "joda-convert" % "2.2.3",
-      "org.scalatest" %% "scalatest" % "3.2.16" % Test,
-      "org.scalatest" %% "scalatest-funspec" % "3.2.16" % Test,
-      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.16" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.17" % Test,
+      "org.scalatest" %% "scalatest-funspec" % "3.2.17" % Test,
+      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.17" % Test,
     )
 )
     credentials += Credentials(


### PR DESCRIPTION
- org.scalatest
  - scalatest (3.2.16 => 3.2.17)
  - scalatest-funspec (3.2.16 => 3.2.17)
  - scalatest-shouldmatchers (3.2.16 => 3.2.17)