### PR TITLE
LOG-1710: Upgrade libraries joda-time, org.scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,11 +26,11 @@ lazy val root = project
     scalafmtOnCompile := true,
     scalacOptions ++= allScalacOptions,
     libraryDependencies ++= Seq(
-      "joda-time" % "joda-time" % "2.12.5",
+      "joda-time" % "joda-time" % "2.12.7",
       "org.joda" % "joda-convert" % "2.2.3",
-      "org.scalatest" %% "scalatest" % "3.2.17" % Test,
-      "org.scalatest" %% "scalatest-funspec" % "3.2.17" % Test,
-      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.17" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.18" % Test,
+      "org.scalatest" %% "scalatest-funspec" % "3.2.18" % Test,
+      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.18" % Test,
     ),
     Test / javaOptions ++= Seq(
       "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",


### PR DESCRIPTION
- joda-time
  - joda-time (2.12.5 => 2.12.7)
- org.scalatest
  - scalatest (3.2.17 => 3.2.18)
  - scalatest-funspec (3.2.17 => 3.2.18)
  - scalatest-shouldmatchers (3.2.17 => 3.2.18)