### PR TITLE
FDN-3333 Post Play 2.9 Dependence Day

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "lib-unit-of-measurement"
 
 organization := "io.flow"
 
-scalaVersion := "2.13.15"
+scalaVersion := "2.13.16"
 
 enablePlugins(GitVersioning)
 git.useGitDescribe := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,4 +15,4 @@ addSbtPlugin("io.flow" % "sbt-flow-linter" % "0.0.59")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.1")


### PR DESCRIPTION

Getting versions updated after merging play296 branches of libraries to main.

Also upgrading to Scala 2.13.16 as scoverage 2.3.x pulls it in.  With our normal DD it opens two PRs but neither builds due to the Scala upgrade then causing a request for a version of scoverage that does not exist.

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>